### PR TITLE
Set Black Dragon and Estark bosses to swap item drops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Progress bar window to make it clear to the user that long randomization runs are making progress. (#15)
 
+### Fixed
+
+- Estark boss and Black Dragon mini-boss not swapping their item drop when randomized. (#16, #17, #18)
+
 ## [0.5.0] - 2025-04-20
 
 ### Added

--- a/dqmj1_randomizer/data/btl_enmy_prm_info.csv
+++ b/dqmj1_randomizer/data/btl_enmy_prm_info.csv
@@ -778,7 +778,7 @@ id,is_boss,is_starter,is_unused_starter,is_gift_monster,is_scout_monster,is_gift
 776,,,,,,,,
 777,,,,,,,,
 778,,,,,,,,
-779,y,,,,,,,
+779,y,,,,,,,y
 780,,,,,,,,
 781,,,,,,,,
 782,,,,,,,,
@@ -851,7 +851,7 @@ id,is_boss,is_starter,is_unused_starter,is_gift_monster,is_scout_monster,is_gift
 849,,,,,,,,
 850,,,,,,,y,
 851,y,,,,,,,
-852,y,,,,,,,
+852,y,,,,,,,y
 853,y,,,,,,,
 854,,,,,,,,
 855,y,,,,,,,


### PR DESCRIPTION
Fixes #16 and #17

Make the Black Dragon mini-boss and Estark boss swap their dropped item when randomizing.

## Checklist
* [x] Update changelog
