### PR TITLE
Cleanup docs to be more approachable

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,54 +9,5 @@ Download the latest release of DQMJ1 Unofficial Randomizer for your operating sy
 https://github.com/ExcaliburZero/dqmj1_randomizer/releases
 
 ## Development
+* [Compile and test](docs/compile_and_test.md) - Instructions for compiling the program from source and running tests.
 * [Release instructions](RELEASE.md) - Instructions on how to create a new versioned release of DQMJ1 Unofficial Randomizer
-
-### Download source code
-```bash
-# Download the source code
-git clone https://github.com/ExcaliburZero/dqmj1_randomizer.git
-cd dqmj1_randomizer
-```
-
-### Setup conda environment
-For building and running the program from source, I recommend using Conda (ex. through [miniforge](https://conda-forge.org/miniforge/)). Conda will manage installing the correct Python version for you.
-
-```bash
-# Install miniforge by downloading and running the installer for your OS listed at the link below
-#
-#   https://conda-forge.org/miniforge/
-
-# Create conda environment
-conda env create -f dqmj1_randomizer.yml
-
-# Activate the conda environment (each time you open a new terminal window)
-conda activate dqmj1_randomizer
-```
-
-### Building executable 
-```bash
-# Install the library
-pip install -e .
-
-# Create the executable
-make compile
-```
-
-### Testing without building executable (faster)
-```bash
-# Install the library
-pip install -e .
-
-# Run the program
-python dqmj1_randomizer/main.py
-```
-
-### Running tests
-```bash
-make test
-```
-
-### Updating regression test baselines
-```bash
-make update_baselines
-```

--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ Download the latest release of DQMJ1 Unofficial Randomizer for your operating sy
 
 https://github.com/ExcaliburZero/dqmj1_randomizer/releases
 
+## Features
+### Randomization
+* Monster randomization - Randomizes the monsters that appear in encounters/battles.
+* Skill set randomization - Randomizes the skills and traits that are rewarded by allocating points to skill sets.
+
+### Quality of Life
+* Remove dialogue - Removes dialog boxes in order to speedup cutscenes and overworld events.
+
 ## Development
 * [Compile and test](docs/compile_and_test.md) - Instructions for compiling the program from source and running tests.
 * [Release instructions](RELEASE.md) - Instructions on how to create a new versioned release of DQMJ1 Unofficial Randomizer

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# DQMJ1 Unofficial Randomizer
+# DQMJ1 Unofficial Randomizer [![Test](https://github.com/ExcaliburZero/dqmj1_randomizer/actions/workflows/test.yml/badge.svg)](https://github.com/ExcaliburZero/dqmj1_randomizer/actions/workflows/test.yml)
 An unofficial randomizer for *Dragon Quest Monsters: Joker 1* for the Nintendo DS.
 
 ![Screenshot of the randomizer GUI](img/screenshot.png)

--- a/docs/compile_and_test.md
+++ b/docs/compile_and_test.md
@@ -1,0 +1,53 @@
+## Compile and test
+
+## Compiling from source
+### Download source code
+```bash
+# Download the source code
+git clone https://github.com/ExcaliburZero/dqmj1_randomizer.git
+cd dqmj1_randomizer
+```
+
+### Setup conda environment
+For building and running the program from source, I recommend using Conda (ex. through [miniforge](https://conda-forge.org/miniforge/)). Conda will manage installing the correct Python version for you.
+
+```bash
+# Install miniforge by downloading and running the installer for your OS listed at the link below
+#
+#   https://conda-forge.org/miniforge/
+
+# Create conda environment
+conda env create -f dqmj1_randomizer.yml
+
+# Activate the conda environment (each time you open a new terminal window)
+conda activate dqmj1_randomizer
+```
+
+### Building executable 
+```bash
+# Install the library
+pip install -e .
+
+# Create the executable
+make compile
+```
+
+## Testing
+### Testing without building executable (faster)
+```bash
+# Install the library
+pip install -e .
+
+# Run the program
+python dqmj1_randomizer/main.py
+```
+
+### Running tests
+```bash
+make test
+```
+
+### Updating regression test baselines
+```bash
+make update_baselines
+```


### PR DESCRIPTION
Make some changes to the readme to make it more approachable for non-programmer users.

* Move compilation and testing instructions into a separate page to make the main page more concise
* Add list of features

## Checklist
* [-] Update changelog
    * N/A since no changes to code