### PR TITLE
Fix dialoge removal error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `AttributeError` that caused randomization to fail when having dialogue removal enabled. (#31, #32)
+- Fixed log message for the number of script files updated when removing dialogue. (#31, #32)
+
 ## [0.5.2] - 2025-05-07
 
 ### Added

--- a/dqmj1_randomizer/randomize/evt.py
+++ b/dqmj1_randomizer/randomize/evt.py
@@ -244,7 +244,7 @@ class Instruction:
             self.arguments, self.instruction_type.arguments
         ):
             if argument_type == at.Bytes:
-                data = argument.copy()
+                data = list(argument)
             elif argument_type == at.AsciiString:
                 for c in argument:
                     data.append(ord(c))

--- a/dqmj1_randomizer/randomize/randomize.py
+++ b/dqmj1_randomizer/randomize/randomize.py
@@ -179,7 +179,6 @@ class RemoveDialog(Task):
         random.shuffle(filenames)
 
         # Load event files
-        scripts: dict[str, Script] = {}
         logging.info("Loading event files.")
         for filename in filenames:
             if not filename.endswith(".evt"):
@@ -208,7 +207,7 @@ class RemoveDialog(Task):
 
             pub.sendMessage("randomize.progress")
 
-        logging.info(f"Successfully updated {len(scripts)} event files.")
+        logging.info(f"Successfully updated {len(filenames)} event files.")
         pub.sendMessage("randomize.progress")
 
     def estimate_steps(self, state: State, rom: ndspy.rom.NintendoDSRom) -> int:


### PR DESCRIPTION
Fixes #31 

Fix error that occurs when using dialogue removal. Also fix the log message that lists the number of script files updated when using that feature.

## Checklist
* [x] Update changelog
